### PR TITLE
Feature/execution serializer extension

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -69,6 +69,7 @@ import cloud.orbit.actors.runtime.DefaultHandlers;
 import cloud.orbit.actors.runtime.DefaultInvocationHandler;
 import cloud.orbit.actors.runtime.DefaultLifetimeExtension;
 import cloud.orbit.actors.runtime.DefaultLocalObjectsCleaner;
+import cloud.orbit.actors.runtime.DefaultResponseCachingExtension;
 import cloud.orbit.actors.runtime.Execution;
 import cloud.orbit.actors.runtime.FastActorClassFinder;
 import cloud.orbit.actors.runtime.Hosting;
@@ -88,7 +89,6 @@ import cloud.orbit.actors.runtime.RandomSelectorExtension;
 import cloud.orbit.actors.runtime.Registration;
 import cloud.orbit.actors.runtime.ReminderController;
 import cloud.orbit.actors.runtime.RemoteReference;
-import cloud.orbit.actors.runtime.DefaultResponseCachingExtension;
 import cloud.orbit.actors.runtime.SerializationHandler;
 import cloud.orbit.actors.runtime.StatelessActorEntry;
 import cloud.orbit.actors.streams.AsyncObserver;
@@ -247,6 +247,7 @@ public class Stage implements Startable, ActorRuntime
         private Messaging messaging;
         private InvocationHandler invocationHandler;
         private Execution execution;
+        private MultiExecutionSerializer<Object> executionSerializer;
         private LocalObjectsCleaner localObjectsCleaner;
 
         private String clusterName;
@@ -293,6 +294,11 @@ public class Stage implements Startable, ActorRuntime
         public Builder execution(Execution execution)
         {
             this.execution = execution;
+            return this;
+        }
+
+        public Builder executionSerializer(MultiExecutionSerializer<Object> executionSerializer) {
+            this.executionSerializer = executionSerializer;
             return this;
         }
 
@@ -421,6 +427,7 @@ public class Stage implements Startable, ActorRuntime
             stage.setClock(clock);
             stage.setExecutionPool(executionPool);
             stage.setExecution(execution);
+            stage.setExecutionSerializer(executionSerializer);
             stage.setObjectCloner(objectCloner);
             stage.setMessageLoopbackObjectCloner(messageLoopbackObjectCloner);
             stage.setMessageSerializer(messageSerializer);
@@ -437,6 +444,7 @@ public class Stage implements Startable, ActorRuntime
             stage.setMessaging(messaging);
             stage.addStickyHeaders(stickyHeaders);
             stage.addBasePackages(basePackages);
+
             if(actorTTLMillis != null) stage.setDefaultActorTTL(actorTTLMillis);
             if(localAddressCacheTTLMillis != null) stage.setLocalAddressCacheTTL(localAddressCacheTTLMillis);
             if(deactivationTimeoutMillis != null) stage.setDeactivationTimeout(deactivationTimeoutMillis);
@@ -510,6 +518,11 @@ public class Stage implements Startable, ActorRuntime
     {
         this.execution = execution;
     }
+
+    public void setExecutionSerializer(MultiExecutionSerializer<Object> executionSerializer) {
+        this.executionSerializer = executionSerializer;
+    }
+
 
     public void setLocalObjectsCleaner(final LocalObjectsCleaner localObjectsCleaner)
     {
@@ -645,7 +658,10 @@ public class Stage implements Startable, ActorRuntime
             executionPool = ExecutorUtils.newScalingThreadPool(executionPoolSize);
         }
 
-        executionSerializer = new WaitFreeMultiExecutionSerializer<>(executionPool);
+        if(executionSerializer == null)
+        {
+            executionSerializer = new WaitFreeMultiExecutionSerializer<>(executionPool);
+        }
 
         if (hosting == null)
         {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeMultiExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeMultiExecutionSerializer.java
@@ -71,7 +71,12 @@ public class WaitFreeMultiExecutionSerializer<T> implements MultiExecutionSerial
 
     public WaitFreeExecutionSerializer getSerializer(T key)
     {
-        return serializers.get(key, o -> new WaitFreeExecutionSerializer(executorService, key));
+        return serializers.get(key, this::getDefaultSerializer);
+    }
+
+    protected WaitFreeExecutionSerializer getDefaultSerializer(final T key)
+    {
+        return new WaitFreeExecutionSerializer(executorService, key);
     }
 
     /**

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/SimpleInvocationHandler.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/SimpleInvocationHandler.java
@@ -90,6 +90,7 @@ public class SimpleInvocationHandler implements InvocationHandler
 
         // Perform the internal invocation
         final Task<Object> invokeResult = doInvoke(runtime, invocation, entry, target, method, reentrant, invoker);
+        invokeResult.putMetadata("methodName", method.getName());
 
         // Link the result to the completion promise
         if (invocation.getCompletion() != null)

--- a/commons/src/main/java/cloud/orbit/concurrent/Task.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/Task.java
@@ -29,7 +29,9 @@
 package cloud.orbit.concurrent;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -64,6 +66,7 @@ import java.util.stream.Stream;
  */
 public class Task<T> extends CompletableFuture<T>
 {
+    private Map<String,String> metaData;
     private static Void NIL = null;
 
     private static Executor commonPool = ExecutorUtils.newScalingThreadPool(100);
@@ -97,6 +100,25 @@ public class Task<T> extends CompletableFuture<T>
             this.defaultExecutor = null;
         }
     }
+
+    public String getMetadata(String key) {
+        lazyMetadataInit();
+        return this.metaData.get(key);
+    }
+
+    public void putMetadata(String key, String value) {
+        lazyMetadataInit();
+        this.metaData.put(key, value);
+    }
+
+    private void lazyMetadataInit()
+    {
+        if(this.metaData == null) {
+            this.metaData = new HashMap<>();
+        }
+    }
+
+
 
     /**
      * Creates an already completed task from the given value.


### PR DESCRIPTION
1) Updated Task to allow us to add arbitrary metadata to it.  This is so we can pass information around like the original name of the method invocation.  
2) Added hooks to execution serializers for adding and removing from the queue
3) Made the executionSerializer configurable when creating the stage, so we can provide our custom version.

The one thing I'm missing is a good place to put the change in SimpleInvocationHandler.java that adds the method name metadata to the task.... Ideally this something we customize ourselves and not part of the Orbit framework.  Any suggestions??


