### PR TITLE
Improve reporting extension points in `WaitFreeExecutionSerializer`.

### DIFF
--- a/actors/core/pom.xml
+++ b/actors/core/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/ActivationReasonExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/ActivationReasonExtension.java
@@ -1,0 +1,17 @@
+package cloud.orbit.actors.extensions;
+
+import cloud.orbit.actors.runtime.AbstractActor;
+
+/**
+ * Listener for actor activation/deactivation proximal cause (i.e. which invocation forced an actor to be awoken).
+ */
+public interface ActivationReasonExtension extends ActorExtension
+{
+
+    /**
+     * Called when an actor has been activated, with a given reason.
+     *
+     * @param actor the actor object being activated
+     */
+    void onActivation(AbstractActor<?> actor, String methodName);
+}

--- a/actors/infinispan-cluster/pom.xml
+++ b/actors/infinispan-cluster/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/json/pom.xml
+++ b/actors/json/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/pom.xml
+++ b/actors/pom.xml
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-internal-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>orbit-actors-parent</artifactId>

--- a/actors/runtime/pom.xml
+++ b/actors/runtime/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -301,7 +301,7 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
     private <T> BiConsumer<T, Throwable> createOnInvocationCompleteHandler(Task<?> task) {
         return (result, error) -> {
             onExecutionComplete(task);
-            task.whenCompleteAsync(this::whenCompleteAsync);
+            this.whenCompleteAsync(result, error);
         };
     }
 

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -102,9 +103,12 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
     {
         return () ->
         {
+            long timePoppedFromQueue = System.currentTimeMillis();
             Task<R> source = InternalUtils.safeInvoke(taskSupplier);
+            long timeSelfExecutionComplete = System.currentTimeMillis();
 
             addedToQueue(timeAddedToQueue, source);
+            onExecutionStarted(source, timeAddedToQueue, timePoppedFromQueue, timeSelfExecutionComplete);
 
             InternalUtils.linkFutures(source, completion);
             return source;
@@ -157,22 +161,30 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
                             if (!task.isDone())
                             {
                                 // this will run whenComplete in another thread
-                                task.whenCompleteAsync(WaitFreeExecutionSerializer.this::whenCompleteAsync, executorService);
+                                task.whenCompleteAsync(createOnInvocationCompleteHandler(task), executorService);
                                 // returning without unlocking, onComplete will do it;
                                 return;
                             }
+
+                            onExecutionComplete(task);
                             unlock();
                             tryExecute(true);
                         });
                         return;
                     }
 
-                    if (taskFuture != null && !taskFuture.isDone())
+                    if (taskFuture != null)
                     {
-                        // this will run whenComplete in another thread
-                        taskFuture.whenCompleteAsync(this::whenCompleteAsync, executorService);
-                        // returning without unlocking, onComplete will do it;
-                        return;
+                        if (taskFuture.isDone()) {
+                            onExecutionComplete(taskFuture);
+                        }
+                        else
+                        {
+                            // this will run whenComplete in another thread
+                            taskFuture.whenCompleteAsync(createOnInvocationCompleteHandler(taskFuture));
+                            // returning without unlocking, onComplete will do it;
+                            return;
+                        }
                     }
                 }
                 catch (Throwable ex)
@@ -195,12 +207,52 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
         } while (!queue.isEmpty());
     }
 
+    /**
+     * @deprecated This method's name is deceptive: it is executed when the task is popped from the queue for execution,
+     * not when the task is actually added to the queue. Prefer the newer onExecutionStarted(), onExecutionComplete().
+     */
+    @Deprecated
     protected <R> void addedToQueue(final long timeAddedToQueue, final Task<R> source)
     {
     }
 
+    @Deprecated
     protected void executedFromQueue(final Task<?> task)
     {
+    }
+
+    /**
+     * Called immediately after an actor invocation has been executed and returned a Task. Provides timestamps for when
+     * that invocation entered the actor's queue, was popped for execution, and when that invocation returned its Task
+     * (the returned Task may or may not be complete yet).
+     *
+     * @param task A Task as returned from the actor's method. In the `@Reentrant` case, this is `Task.fromValue(null)`.
+     * @param timeAddedToQueue A timestamp taken when the invocation was enqueued.
+     * @param timePoppedFromQueue A timestamp taken when the invocation was pulled out of the queue to be executed.
+     * @param timeSelfExecutionComplete A timestamp taken when the invocation had finished returning a Task that
+     *                                  represents any asynchronous computation.
+     */
+    protected void onExecutionStarted(
+            final Task<?> task,
+            final long timeAddedToQueue,
+            final long timePoppedFromQueue,
+            final long timeSelfExecutionComplete
+    ) {
+        // do-nothing: this is an extension point
+    }
+
+    /**
+     * Called immediately after an actor invocation's returned Task has become complete (whether normally or
+     * exceptionally), but before the execution serializer has started the next Task in the queue.
+     *
+     * NOTE: Methods that have been annotated with `@Reentrant` will call this method immediately, before the underlying
+     * execution is actually complete.
+     *
+     * @param task A Task as returned from the actor's method. In the `@Reentrant` case, this is `Task.fromValue(null)`.
+     */
+    protected void onExecutionComplete(Task<?> task)
+    {
+        // do-nothing: this is an extension point
     }
 
     private void wrapExecution(final Supplier<Task<?>> toRun, final Task<?> taskFuture)
@@ -244,6 +296,13 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
     private boolean lock()
     {
         return lockUpdater.compareAndSet(this, 0, 1);
+    }
+
+    private <T> BiConsumer<T, Throwable> createOnInvocationCompleteHandler(Task<?> task) {
+        return (result, error) -> {
+            onExecutionComplete(task);
+            task.whenCompleteAsync(this::whenCompleteAsync);
+        };
     }
 
     private <T> void whenCompleteAsync(T result, Throwable error)

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -181,7 +181,7 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
                         else
                         {
                             // this will run whenComplete in another thread
-                            taskFuture.whenCompleteAsync(createOnInvocationCompleteHandler(taskFuture));
+                            taskFuture.whenCompleteAsync(createOnInvocationCompleteHandler(taskFuture), executorService);
                             // returning without unlocking, onComplete will do it;
                             return;
                         }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/SimpleInvocationHandler.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/SimpleInvocationHandler.java
@@ -108,7 +108,9 @@ public class SimpleInvocationHandler implements InvocationHandler
         // If reentrant we say we are done
         if (reentrant)
         {
-            return Task.fromValue(null);
+            Task<Object> task = Task.fromValue(null);
+            task.putMetadata("methodName", method.getName());
+            return task;
         }
 
         return invokeResult;

--- a/actors/test/actor-tests/pom.xml
+++ b/actors/test/actor-tests/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/test/benchmarks/pom.xml
+++ b/actors/test/benchmarks/pom.xml
@@ -35,7 +35,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-internal-parent</artifactId>
-        <version>1.7.0.1-SNAPSHOT</version>
+        <version>1.7.0.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	
 	<groupId>cloud.orbit</groupId>
     <artifactId>orbit-internal-parent</artifactId>
-    <version>1.7.0.1-SNAPSHOT</version>
+    <version>1.7.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Orbit Internal Parent</name>
 


### PR DESCRIPTION
Replace `addedToQueue` (which was actually called when the invocation was removed from the queue) and `executedFromQueue` (which was called prior to the invocation being complete) with more detailed extension points.

These new extension points provide enough information to determine:

* How long the invocation waited in the queue.
* How much time it took for the Actor's method to return a Task (which I've been terming the "self" time).
* How much additional time it took for the returned Task to be marked complete (which I've been terming the "async" time).

Also, the invocation pathway for @Reentrant tasks now includes the method name in returned Task metadata.