### PR TITLE
Fix an actor mutex / execution serialization fault

### DIFF
--- a/actors/core/pom.xml
+++ b/actors/core/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/actors/infinispan-cluster/pom.xml
+++ b/actors/infinispan-cluster/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/json/pom.xml
+++ b/actors/json/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/pom.xml
+++ b/actors/pom.xml
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-internal-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>orbit-actors-parent</artifactId>

--- a/actors/runtime/pom.xml
+++ b/actors/runtime/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
@@ -115,7 +115,7 @@ public class ActorEntry<T extends AbstractActor> extends ActorBaseEntry<T>
         final Task<R> result = new Task<>();
         result.putMetadata(METHOD_NAME, "activate-for-unknown-task");
 
-        final Task<Void> activateThenApplyTask = activateTask.thenRun(() -> {
+        final Task<R> activateThenApplyTask = activateTask.thenCompose(() -> {
             actorTaskContext.setActor(this.getObject());
             final Task<R> applyTask = function.apply(this);
             final String methodName = applyTask.getMetadata(METHOD_NAME);
@@ -124,6 +124,8 @@ public class ActorEntry<T extends AbstractActor> extends ActorBaseEntry<T>
             if ( shouldSendActivationReason ) {
                 runtime.getAllExtensions(ActivationReasonExtension.class).forEach(v -> v.onActivation(this.getObject(), methodName));
             }
+
+            return applyTask;
         });
 
         InternalUtils.linkFutures(activateThenApplyTask, result);

--- a/actors/test/actor-tests/pom.xml
+++ b/actors/test/actor-tests/pom.xml
@@ -32,7 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/actors/test/benchmarks/pom.xml
+++ b/actors/test/benchmarks/pom.xml
@@ -35,7 +35,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-actors-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <parent>
         <groupId>cloud.orbit</groupId>
         <artifactId>orbit-internal-parent</artifactId>
-        <version>1.7.0.2-SNAPSHOT</version>
+        <version>1.7.0.3-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	
 	<groupId>cloud.orbit</groupId>
     <artifactId>orbit-internal-parent</artifactId>
-    <version>1.7.0.2-SNAPSHOT</version>
+    <version>1.7.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Orbit Internal Parent</name>
 


### PR DESCRIPTION
Fault was introduced in the method-name branch. There was a dangling Task<R> that represented the async portions of an actor method invocation which was not properly chained.