### PR TITLE
Feature/reminder controller start2

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -203,6 +203,9 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
     @Config("orbit.actors.numReminderControllers")
     private int numReminderControllers = 1;
 
+    @Config("orbit.actors.reminderController.autostart")
+    private boolean autoStartReminderControllers = true;
+
     @Config("orbit.actors.broadcastActorDeactivations")
     private boolean broadcastActorDeactivations = true;
 
@@ -271,6 +274,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         private Long actorTTLMillis = null;
         private Long localAddressCacheTTLMillis = null;
         private Integer numReminderControllers = null;
+        private Boolean autoStartReminderControllers = null;
         private Boolean broadcastActorDeactivations = null;
         private Long deactivationTimeoutMillis;
         private Integer concurrentDeactivations;
@@ -429,6 +433,12 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
             return this;
         }
 
+        public Builder autoStartReminderControllers(final boolean autoStart)
+        {
+            this.autoStartReminderControllers = autoStart;
+            return this;
+        }
+
         public Builder deactivationTimeout(final long duration, final TimeUnit timeUnit)
         {
             this.deactivationTimeoutMillis = timeUnit.toMillis(duration);
@@ -474,6 +484,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
             if(actorTTLMillis != null) stage.setDefaultActorTTL(actorTTLMillis);
             if(localAddressCacheTTLMillis != null) stage.setLocalAddressCacheTTL(localAddressCacheTTLMillis);
             if(numReminderControllers != null) stage.setNumReminderControllers(numReminderControllers);
+            if(autoStartReminderControllers != null) stage.setAutoStartReminderControllers(autoStartReminderControllers);
             if(deactivationTimeoutMillis != null) stage.setDeactivationTimeout(deactivationTimeoutMillis);
             if(concurrentDeactivations != null) stage.setConcurrentDeactivations(concurrentDeactivations);
             if(broadcastActorDeactivations != null) stage.setBroadcastActorDeactivations(broadcastActorDeactivations);
@@ -641,11 +652,21 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
 
     public void setNumReminderControllers(final int numReminderControllers)
     {
+        if (!autoStartReminderControllers)
+        {
+            return;
+        }
+        
         if(numReminderControllers < 1)
         {
             throw new IllegalArgumentException("Must specify at least 1 reminder controller shard");
         }
         this.numReminderControllers = numReminderControllers;
+    }
+
+    public void setAutoStartReminderControllers(final boolean autoStart)
+    {
+        this.autoStartReminderControllers = autoStart;
     }
 
     public void setDeactivationTimeout(long deactivationTimeoutMs)

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -1152,6 +1152,15 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         return hosting.getServerNodes();
     }
 
+    public List<NodeAddress> getRunningServerNodes()
+    {
+        if (hosting == null)
+        {
+            return Collections.emptyList();
+        }
+        return hosting.getServerNodes();
+    }
+
     public NodeCapabilities.NodeState getState()
     {
         return state;

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -1158,7 +1158,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         {
             return Collections.emptyList();
         }
-        return hosting.getServerNodes();
+        return hosting.getRunningServerNodes();
     }
 
     public NodeCapabilities.NodeState getState()

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -652,11 +652,6 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
 
     public void setNumReminderControllers(final int numReminderControllers)
     {
-        if (!autoStartReminderControllers)
-        {
-            return;
-        }
-        
         if(numReminderControllers < 1)
         {
             throw new IllegalArgumentException("Must specify at least 1 reminder controller shard");
@@ -939,6 +934,11 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
 
     private void startReminderController()
     {
+        if (!autoStartReminderControllers)
+        {
+            return;
+        }
+
         if(useReminderShards())
         {
             IntStream.range(0, numReminderControllers).forEach(i ->

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -144,6 +144,19 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
         return Collections.unmodifiableList(set);
     }
 
+    public List<NodeAddress> getRunningServerNodes()
+    {
+        final ArrayList<NodeAddress> set = new ArrayList<>(serverNodes.size());
+        for (final NodeInfo s : serverNodes)
+        {
+            if (s.state == NodeState.RUNNING)
+            {
+                set.add(s.address);
+            }
+        }
+        return Collections.unmodifiableList(set);
+    }
+
     public Task<?> notifyStateChange()
     {
         return Task.allOf(activeNodes.values().stream()


### PR DESCRIPTION
Provides ability to delay placement of reminder controller actors until after cluster has established which allows for even distribution of sharded reminder controller actors across the cluster 