### PR TITLE
Flush performance

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultResponseCachingExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultResponseCachingExtension.java
@@ -91,7 +91,7 @@ public class DefaultResponseCachingExtension
      * Key: Pairing of the Actor address, and a hash of the parameters being passed into the method
      * Value: The method result corresponding with the actor's call to the method with provided parameters
      */
-    private final Cache<Method, Cache<Pair<Addressable, String>, Task>> masterCache = Caffeine.newBuilder().build();
+    private final Cache<Method, Cache<Addressable, Cache<String, Task>>> masterCache = Caffeine.newBuilder().build();
 
     public static void setCacheExecutor(final Executor cacheExecutor)
     {
@@ -110,7 +110,7 @@ public class DefaultResponseCachingExtension
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
     }
 
-    private Pair<Method, Long> getCacheSize(final Map.Entry<Method, Cache<Pair<Addressable, String>, Task>> methodCacheEntry)
+    private Pair<Method, Long> getCacheSize(final Map.Entry<Method, Cache<Addressable, Cache<String, Task>>> methodCacheEntry)
     {
         return Pair.of(methodCacheEntry.getKey(), methodCacheEntry.getValue().estimatedSize());
     }
@@ -122,8 +122,16 @@ public class DefaultResponseCachingExtension
     @Override
     public Task<?> get(Method method, Pair<Addressable, String> key)
     {
-        final Cache<Pair<Addressable, String>, Task> cache = getIfPresent(method);
-        return cache != null ? cache.getIfPresent(key) : null;
+        Task<?> result = null;
+        final Cache<Addressable, Cache<String, Task>> methodCache = getIfPresent(method);
+
+        if (methodCache != null)
+        {
+            final Cache<String, Task> addressableCache = methodCache.getIfPresent(key.getLeft());
+            result = addressableCache != null ? addressableCache.getIfPresent(key.getRight()) : null;
+        }
+
+        return result;
     }
 
     /**
@@ -132,26 +140,35 @@ public class DefaultResponseCachingExtension
     @Override
     public void put(Method method, Pair<Addressable, String> key, Task<?> value)
     {
-        final Cache<Pair<Addressable, String>, Task> cache = getCache(method);
-        cache.put(key, value);
+        final Cache<Addressable, Cache<String, Task>> cache = getMethodCache(method);
+        final Cache<String, Task> addressableCache = getAddressableCache(cache, key.getLeft());
+        addressableCache.put(key.getRight(), value);
     }
 
-    private Cache<Pair<Addressable, String>, Task> getIfPresent(Method method)
+    private Cache<Addressable, Cache<String, Task>> getIfPresent(Method method)
     {
-        final CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
-        if (cacheResponse == null)
-        {
-            throw new IllegalArgumentException("Passed non-CacheResponse method.");
-        }
-
         return masterCache.getIfPresent(method);
+    }
+
+    private Cache<String, Task> getAddressableCache(final Cache<Addressable, Cache<String, Task>> methodCache, final Addressable addressable)
+    {
+        return methodCache.get(addressable, key -> {
+            Caffeine<Object, Object> builder = Caffeine.newBuilder();
+            if (cacheExecutor != null)
+            {
+                builder.executor(cacheExecutor);
+            }
+            return builder
+                    .ticker(clock == null ? Ticker.systemTicker() : () -> TimeUnit.MILLISECONDS.toNanos(clock.millis()))
+                    .build();
+        });
     }
 
     /**
      * Retrieves the cache for a CacheResponse-annotated method.
      * One is created if necessary.
      */
-    private Cache<Pair<Addressable, String>, Task> getCache(Method method)
+    private Cache<Addressable, Cache<String, Task>> getMethodCache(Method method)
     {
         final CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
         if (cacheResponse == null)
@@ -178,13 +195,8 @@ public class DefaultResponseCachingExtension
     public Task<Void> flush(Actor actor)
     {
         final RemoteReference actorReference = (RemoteReference) actor;
-        final Class interfaceClass = RemoteReference.getInterfaceClass(actorReference);
-
-        masterCache.asMap().entrySet().forEach(entry -> {
-            if (interfaceClass.equals(entry.getKey().getDeclaringClass()))
-            {
-                entry.getValue().asMap().keySet().removeIf(addressablePair -> addressablePair.getLeft().equals(actorReference));
-            }
+        masterCache.asMap().forEach((method, cache) -> {
+            cache.invalidate(actorReference);
         });
         return Task.done();
     }

--- a/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/CacheResponseBenchmark.java
+++ b/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/CacheResponseBenchmark.java
@@ -1,0 +1,201 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.annotation.CacheResponse;
+import cloud.orbit.actors.cache.ExecutionCacheFlushManager;
+import cloud.orbit.actors.extensions.json.InMemoryJSONStorageExtension;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.actors.util.IdUtils;
+import cloud.orbit.concurrent.Task;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Threads(1)
+public class CacheResponseBenchmark
+{
+    private static final int MAX_ACTORS = 5000;
+
+    private static final int MAX_PARAMS = 10;
+
+    private Stage stage;
+
+    private int actorId = 0;
+
+    private int param = 0;
+
+    public interface Hello extends Actor
+    {
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreetingCached(final String param);
+
+        Task<String> getGreeting(final String param);
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreetingWithDelayCached(final String param);
+
+        Task<String> getGreetingWithDelay(final String param);
+
+    }
+
+    public static class HelloActor extends AbstractActor implements Hello
+    {
+
+        @Override
+        public Task<String> getGreetingCached(final String param)
+        {
+            return Task.fromValue(IdUtils.urlSafeString(32));
+        }
+
+        @Override
+        public Task<String> getGreeting(final String param)
+        {
+            return Task.fromValue(IdUtils.urlSafeString(32));
+        }
+
+        @Override
+        public Task<String> getGreetingWithDelayCached(final String param)
+        {
+            return Task.sleep(1, TimeUnit.MILLISECONDS).thenApply(v -> IdUtils.urlSafeString(32));
+        }
+
+        @Override
+        public Task<String> getGreetingWithDelay(final String param)
+        {
+            return Task.sleep(1, TimeUnit.MILLISECONDS).thenApply(v -> IdUtils.urlSafeString(32));
+        }
+    }
+
+    @Setup
+    public void setup()
+    {
+        System.setProperty("java.net.preferIPv4Stack", "true");
+        this.stage = new Stage.Builder()
+                .extensions(new InMemoryJSONStorageExtension(new ConcurrentHashMap<>()))
+                .mode(Stage.StageMode.HOST)
+                .clusterName(IdUtils.urlSafeString(32))
+                .executionPoolSize(Math.max(1, Runtime.getRuntime().availableProcessors() / 2))
+                .build();
+        this.stage.start().join();
+        this.stage.bind();
+        this.actorId = 0;
+        this.param = 0;
+    }
+
+    @TearDown
+    public void tearDown()
+    {
+        this.stage.stop().join();
+    }
+
+    @Benchmark
+    @Warmup(iterations = 100)
+    public void get(final CacheResponseBenchmark state)
+    {
+        Actor.getReference(Hello.class, Objects.toString(state.actorId))
+                .getGreetingWithDelay(Objects.toString(state.param)).join();
+        state.param++;
+        if (state.param >= 10)
+        {
+            state.actorId++;
+            state.param = 0;
+            if (state.actorId >= MAX_ACTORS)
+            {
+                state.actorId = 0;
+            }
+        }
+    }
+
+    @Benchmark
+    @Warmup(iterations = 100)
+    public void getCached(final CacheResponseBenchmark state)
+    {
+        Actor.getReference(Hello.class, Objects.toString(state.actorId))
+                .getGreetingWithDelayCached(Objects.toString(state.param)).join();
+        state.param++;
+        if (state.param >= 10)
+        {
+            state.actorId++;
+            state.param = 0;
+            if (state.actorId >= MAX_ACTORS)
+            {
+                state.actorId = 0;
+            }
+        }
+    }
+
+    @Benchmark
+    public void put(final CacheResponseBenchmark state)
+    {
+        Actor.getReference(Hello.class, Objects.toString(state.actorId))
+                .getGreeting(Objects.toString(state.param)).join();
+        state.param++;
+        if (state.param >= MAX_PARAMS)
+        {
+            state.actorId++;
+            state.param = 0;
+        }
+    }
+
+    @Benchmark
+    public void putCached(final CacheResponseBenchmark state)
+    {
+        Actor.getReference(Hello.class, Objects.toString(state.actorId))
+                .getGreetingCached(Objects.toString(state.param)).join();
+        state.param++;
+        if (state.param >= MAX_PARAMS)
+        {
+            state.actorId++;
+            state.param = 0;
+        }
+    }
+
+}

--- a/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/CacheResponseFlushBenchmark.java
+++ b/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/CacheResponseFlushBenchmark.java
@@ -1,0 +1,310 @@
+/*
+ Copyright (C) 2018 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.annotation.CacheResponse;
+import cloud.orbit.actors.cache.ExecutionCacheFlushManager;
+import cloud.orbit.actors.extensions.json.InMemoryJSONStorageExtension;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.actors.runtime.ActorProfiler;
+import cloud.orbit.actors.util.IdUtils;
+import cloud.orbit.concurrent.Task;
+import cloud.orbit.profiler.ProfileDump;
+import cloud.orbit.profiler.ProfilerData;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@Threads(1)
+public class CacheResponseFlushBenchmark
+{
+    private static final int NUM_PARAMS = 10;
+
+    private Stage stage;
+
+    private boolean warmCache = false;
+
+    private int actorId = 0;
+
+    public interface Hello extends Actor
+    {
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting(final String param);
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting1();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting2();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting3();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting4();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting5();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting6();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting7();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting8();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting9();
+
+        @CacheResponse(maxEntries = 20_000_000, ttlDuration = 1, ttlUnit = TimeUnit.DAYS)
+        Task<String> getGreeting10();
+
+        Task<Void> flushGreeting();
+    }
+
+    public static class HelloActor extends AbstractActor implements Hello
+    {
+
+        @Override
+        public Task<String> getGreeting(final String param)
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting1()
+        {
+            return Task.fromValue(IdUtils.urlSafeString(32));
+        }
+
+        @Override
+        public Task<String> getGreeting2()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting3()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting4()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting5()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting6()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting7()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting8()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting9()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<String> getGreeting10()
+        {
+            return this.getGreeting1();
+        }
+
+        @Override
+        public Task<Void> flushGreeting()
+        {
+            return ExecutionCacheFlushManager.flushAll(this);
+        }
+
+    }
+
+    @Setup
+    public void setup()
+    {
+        System.setProperty("java.net.preferIPv4Stack", "true");
+        this.stage = new Stage.Builder()
+                .extensions(new InMemoryJSONStorageExtension(new ConcurrentHashMap<>()))
+                .mode(Stage.StageMode.HOST)
+                .clusterName(IdUtils.urlSafeString(32))
+                .executionPoolSize(Math.max(1, Runtime.getRuntime().availableProcessors() / 2))
+                .build();
+        this.stage.start().join();
+        this.stage.bind();
+        this.actorId = 0;
+        this.warmCache = true;
+    }
+
+    @TearDown
+    public void tearDown()
+    {
+        this.stage.stop().join();
+    }
+
+    @Benchmark
+    public void _0_flushThroughput10(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 10);
+    }
+
+    @Benchmark
+    public void _1_flushThroughput100(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 100);
+    }
+
+    @Benchmark
+    public void _2_flushThroughput500(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 500);
+    }
+
+    @Benchmark
+    public void _3_flushThroughput1000(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 1_000);
+    }
+
+    @Benchmark
+    public void _4_flushThroughput10000(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 10_000);
+    }
+
+    @Benchmark
+    public void _5_flushThroughput100000(final CacheResponseFlushBenchmark state)
+    {
+        this.runBenchmark(state, 100_000);
+    }
+
+    private void runBenchmark(final CacheResponseFlushBenchmark state, final int numActors)
+    {
+        maybePrewarmCache(state, numActors);
+
+        Actor.getReference(Hello.class, Objects.toString(state.actorId))
+                .flushGreeting().join();
+        this.warmCacheForActor(Objects.toString(state.actorId));
+
+        state.actorId++;
+        if (state.actorId >= numActors)
+        {
+            state.actorId = 0;
+        }
+
+    }
+
+    private void maybePrewarmCache(final CacheResponseFlushBenchmark state, final int numActors)
+    {
+        if (state.warmCache)
+        {
+            this.preWarmCache(numActors);
+            state.warmCache = false;
+        }
+    }
+
+    private void preWarmCache(final int numActors)
+    {
+        System.out.println("Warming cache with " + numActors + "x" + NUM_PARAMS);
+        IntStream.range(0, numActors).parallel().forEach(i ->
+                this.warmCacheForActor(Objects.toString(i)));
+    }
+
+    private void warmCacheForActor(final String actorId)
+    {
+        final Hello actor = Actor.getReference(Hello.class,
+                Objects.toString(actorId));
+
+        final ArrayList<Task> tasks = new ArrayList<>();
+
+        tasks.add(actor.getGreeting1());
+        tasks.add(actor.getGreeting2());
+        tasks.add(actor.getGreeting3());
+        tasks.add(actor.getGreeting4());
+        tasks.add(actor.getGreeting5());
+        tasks.add(actor.getGreeting6());
+        tasks.add(actor.getGreeting7());
+        tasks.add(actor.getGreeting8());
+        tasks.add(actor.getGreeting9());
+        tasks.add(actor.getGreeting10());
+
+        IntStream.range(0, NUM_PARAMS).forEach(j ->
+                tasks.add(actor.getGreeting(Objects.toString(j))));
+
+        Task.allOf(tasks).join();
+
+    }
+
+}


### PR DESCRIPTION
# Summary

Moving cache implementation structure from method -> {addressable, params} -> task
to method -> addressable -> params -> task.

This facilitates updating the flush implementation so it doesn't have to walk the entire addressable structure to flush the cache for an actor.

# Benchmarks

Existing flush implementation throughput

```
Benchmark                                              Mode  Cnt     Score     Error  Units
CacheResponseFlushBenchmark._0_flushThroughput10      thrpt   20  2246.177 ± 105.392  ops/s
CacheResponseFlushBenchmark._1_flushThroughput100     thrpt   20  1987.013 ±  96.470  ops/s
CacheResponseFlushBenchmark._2_flushThroughput500     thrpt   20   971.735 ±  22.070  ops/s
CacheResponseFlushBenchmark._3_flushThroughput1000    thrpt   20   386.572 ±  36.502  ops/s
CacheResponseFlushBenchmark._4_flushThroughput10000   thrpt   20    36.829 ±   1.787  ops/s
CacheResponseFlushBenchmark._5_flushThroughput100000  thrpt   20     3.088 ±   0.023  ops/s
```

New flush implementation throughput

```
CacheResponseFlushBenchmark._0_flushThroughput10      thrpt   20  2807.531 ± 171.453  ops/s
CacheResponseFlushBenchmark._1_flushThroughput100     thrpt   20  2862.684 ± 185.700  ops/s
CacheResponseFlushBenchmark._2_flushThroughput500     thrpt   20  2906.574 ± 135.972  ops/s
CacheResponseFlushBenchmark._3_flushThroughput1000    thrpt   20  2806.602 ± 162.794  ops/s
CacheResponseFlushBenchmark._4_flushThroughput10000   thrpt   20  2709.984 ± 144.680  ops/s
CacheResponseFlushBenchmark._5_flushThroughput100000  thrpt   20  2348.267 ± 377.029  ops/s
```

Old implementation flush throughput degrades with more entries in the cache. 
New implementation flush throughput stays much more consistent with more entries.

Old implementation get/put throughput

```
Benchmark                          Mode  Cnt       Score      Error  Units
CacheResponseBenchmark.get        thrpt   20     714.949 ±   37.018  ops/s
CacheResponseBenchmark.getCached  thrpt   20  191107.633 ± 3111.927  ops/s
CacheResponseBenchmark.put        thrpt   20   39724.746 ± 2623.486  ops/s
CacheResponseBenchmark.putCached  thrpt   20   28512.045 ± 5513.049  ops/s
```

New implementation get/put throughput

```
CacheResponseBenchmark.get        thrpt   20     688.818 ±    8.487  ops/s
CacheResponseBenchmark.getCached  thrpt   20  192996.263 ± 7377.763  ops/s
CacheResponseBenchmark.put        thrpt   20   40627.001 ± 2837.266  ops/s
CacheResponseBenchmark.putCached  thrpt   20   30988.189 ± 3545.611  ops/s
```

Throughtput for get/put not affected by the improvement to flush.

# Load Testing

Existing implementation can't keep up with the flush rate.

<img width="689" alt="screen shot 2018-04-24 at 8 52 07 am" src="https://user-images.githubusercontent.com/318994/39188015-cd7cb4e2-479c-11e8-9fe7-957be8fc1663.png">

<img width="685" alt="screen shot 2018-04-24 at 8 50 35 am" src="https://user-images.githubusercontent.com/318994/39187980-b5c19642-479c-11e8-9bb2-82dc00dbc318.png">

Existing implementation performs much better.

<img width="686" alt="screen shot 2018-04-24 at 8 52 41 am" src="https://user-images.githubusercontent.com/318994/39188052-df60e1d8-479c-11e8-835f-e55d25c0d74b.png">

<img width="685" alt="screen shot 2018-04-24 at 8 50 53 am" src="https://user-images.githubusercontent.com/318994/39188033-d64d336c-479c-11e8-9c49-f75e98752112.png">